### PR TITLE
python needs to be 2.7

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ module "appsync_athena_resolver" {
   ]
 
   policy_arns_count = 2
-  runtime           = "python3.7"
+  runtime           = "python2.7"
   source            = "QuiNovas/lambdalambdalambda/aws"
   timeout           = 30
   version           = "0.2.0"


### PR DESCRIPTION
Until the new lambda-pyathena library is built into the underlying lambda function